### PR TITLE
src: Save reqwest Client in SupabaseClient and migrate to thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.86"
 deprecate-until = "0.1.1"
 regex = { version = "1.10.5", optional = false }
 serde = "1.0.204"
+thiserror = "1.0.63"
 
 
 

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -7,7 +7,7 @@
 //!     
 
 use crate::SupabaseClient;
-use reqwest::{Client, Response};
+use reqwest::Response;
 use serde_json::json;
 
 impl SupabaseClient {
@@ -32,7 +32,7 @@ impl SupabaseClient {
     ///     let client = SupabaseClient::new(
     ///         "your_supabase_url".to_string(),
     ///         "your_supabase_key".to_string()
-    ///     );
+    ///     ).unwrap();
     ///     let result = client.delete("your_table_name", "row_id").await;
     ///     match result {
     ///         Ok(_) => println!("Row deleted successfully"),
@@ -49,12 +49,6 @@ impl SupabaseClient {
         // Construct the endpoint URL for the delete operation
         let endpoint: String = format!("{}/rest/v1/{}?id=eq.{}", self.url, table_name, id);
 
-        #[cfg(feature = "rustls")]
-        let client = Client::builder().use_rustls_tls().build().unwrap();
-
-        #[cfg(not(feature = "rustls"))]
-        let client = Client::new();
-
         #[cfg(feature = "nightly")]
         use crate::nightly::print_nightly_warning;
         #[cfg(feature = "nightly")]
@@ -63,7 +57,8 @@ impl SupabaseClient {
         let body: serde_json::Value = json!({}); // this is temporary, will be used for more complex queries
 
         // Send the delete request and handle the response
-        let response: Response = match client
+        let response: Response = match self
+            .client
             .delete(&endpoint)
             .header("apikey", &self.api_key)
             .header("Authorization", &format!("Bearer {}", &self.api_key))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,54 +3,37 @@
 //! This module provides error handling utilities for the Supabase client.
 
 use anyhow::Error;
-use std::fmt;
 
-#[derive(Debug)]
-pub struct ErrorSupabase {
-    pub message: String,
-}
-
-impl fmt::Display for ErrorSupabase {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl std::error::Error for ErrorSupabase {}
-
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum ErrorTypes {
+    #[error("Unknown error")]
     UnknownError,
+    #[error("API key is missing")]
     ApiKeyMissing,
+    #[error("Authorization failed")]
     AuthorizationFailed,
+    #[error("Invalid query")]
     InvalidQuery,
+    #[error("Reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("Environment variable error: {0}")]
+    EnvironmentError(#[from] std::env::VarError),
 }
 
-impl fmt::Display for ErrorTypes {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ErrorTypes::UnknownError => write!(f, "Unknown error"),
-            ErrorTypes::ApiKeyMissing => write!(f, "API key is missing"),
-            ErrorTypes::AuthorizationFailed => write!(f, "Authorization failed"),
-            ErrorTypes::InvalidQuery => write!(f, "Invalid query"),
-        }
-    }
-}
+pub type Result<Type> = std::result::Result<Type, ErrorTypes>;
 
-impl std::error::Error for ErrorTypes {}
-
-pub async fn unknown_error() -> Result<(), Error> {
+pub async fn unknown_error() -> std::result::Result<(), Error> {
     Err(Error::msg("SUPABASE_RS: unknown error"))
 }
 
-pub async fn api_key_missing_error() -> Result<(), Error> {
+pub async fn api_key_missing_error() -> std::result::Result<(), Error> {
     Err(Error::msg("SUPABASE_RS: API key is missing"))
 }
 
-pub async fn authorization_failed_error() -> Result<(), Error> {
+pub async fn authorization_failed_error() -> std::result::Result<(), Error> {
     Err(Error::msg("SUPABASE_RS: Authorization failed"))
 }
 
-pub async fn invalid_query_error() -> Result<(), Error> {
+pub async fn invalid_query_error() -> std::result::Result<(), Error> {
     Err(Error::msg("SUPABASE_RS: Invalid query"))
 }

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -22,7 +22,7 @@
 //! async fn main() {
 //!     let client = SupabaseClient::new(
 //!         "your_supabase_url".to_string(), "your_supabase_key".to_string()
-//!     );
+//!     ).unwrap();
 //!     let insert_result = client.insert(
 //!         "your_table_name", json!({"column_name": "value"})
 //!     ).await;
@@ -38,7 +38,7 @@
 //! async fn main() {
 //!     let client = SupabaseClient::new(
 //!         "your_supabase_url".to_string(), "your_supabase_key".to_string()
-//!     );
+//!     ).unwrap();
 //!     let unique_insert_result = client.insert_if_unique(
 //!         "your_table_name", json!({"unique_column_name": "unique_value"})
 //!     ).await;
@@ -51,7 +51,7 @@
 //! and `Err(String)` contains an error message in case of failure.
 
 use crate::{generate_random_id, SupabaseClient};
-use reqwest::{Client, Response};
+use reqwest::Response;
 use serde_json::{json, Value};
 
 impl SupabaseClient {
@@ -83,12 +83,6 @@ impl SupabaseClient {
     pub async fn insert(&self, table_name: &str, mut body: Value) -> Result<String, String> {
         let endpoint: String = format!("{}/rest/v1/{}", self.url, table_name);
 
-        #[cfg(feature = "rustls")]
-        let client = Client::builder().use_rustls_tls().build().unwrap();
-
-        #[cfg(not(feature = "rustls"))]
-        let client = Client::new();
-
         #[cfg(feature = "nightly")]
         use crate::nightly::print_nightly_warning;
         #[cfg(feature = "nightly")]
@@ -97,7 +91,8 @@ impl SupabaseClient {
         let new_id: i64 = generate_random_id();
         body["id"] = json!(new_id);
 
-        let response: Response = match client
+        let response: Response = match self
+            .client
             .post(&endpoint)
             .header("apikey", &self.api_key)
             .header("Authorization", format!("Bearer {}", &self.api_key))
@@ -156,18 +151,13 @@ impl SupabaseClient {
     ) -> Result<(), String> {
         let endpoint: String = format!("{}/rest/v1/{}", self.url, table_name);
 
-        #[cfg(feature = "rustls")]
-        let client = Client::builder().use_rustls_tls().build().unwrap();
-
-        #[cfg(not(feature = "rustls"))]
-        let client = Client::new();
-
         #[cfg(feature = "nightly")]
         use crate::nightly::print_nightly_warning;
         #[cfg(feature = "nightly")]
         print_nightly_warning();
 
-        let response: Response = match client
+        let response: Response = match self
+            .client
             .post(&endpoint)
             .header("apikey", &self.api_key)
             .header("Authorization", format!("Bearer {}", &self.api_key))
@@ -206,7 +196,7 @@ impl SupabaseClient {
     /// #[tokio::main]
     /// async fn main() {
     ///     // Initialize the Supabase client
-    ///     let client = SupabaseClient::new("your_supabase_url".to_string(), "your_supabase_key".to_string());
+    ///     let client = SupabaseClient::new("your_supabase_url".to_string(), "your_supabase_key".to_string()).unwrap();
     ///
     ///     // This will insert a new row into the table if the value is unique
     ///     let unique_insert_result = client.insert_if_unique(
@@ -300,18 +290,13 @@ impl SupabaseClient {
         };
         let endpoint: String = format!("{}/rest/v1/{}", self.url, table_name);
 
-        #[cfg(feature = "rustls")]
-        let client = Client::builder().use_rustls_tls().build().unwrap();
-
-        #[cfg(not(feature = "rustls"))]
-        let client = Client::new();
-
         #[cfg(feature = "nightly")]
         use crate::nightly::print_nightly_warning;
         #[cfg(feature = "nightly")]
         print_nightly_warning();
 
-        let response: Response = match client
+        let response: Response = match self
+            .client
             .post(&endpoint)
             .header("apikey", &self.api_key)
             .header("Authorization", format!("Bearer {}", &self.api_key))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //!     let supabase_client: SupabaseClient = SupabaseClient::new(
 //!         var("SUPABASE_URL").unwrap(),
 //!         var("SUPABASE_KEY").unwrap()
-//!         );
+//!         ).unwrap();
 //!
 //!         supabase_client
 //!    }
@@ -326,6 +326,7 @@
 
 use rand::prelude::ThreadRng;
 use rand::Rng;
+use reqwest::Client;
 
 pub mod delete;
 pub mod errors;
@@ -346,6 +347,8 @@ pub mod nightly;
 pub mod realtime;
 pub mod storage;
 
+use errors::Result;
+
 /// A client structure for interacting with Supabase services.
 ///
 /// This structure holds the necessary details to make requests to the Supabase API.
@@ -356,8 +359,9 @@ pub mod storage;
 /// - `api_key`: The API key used for authenticating requests to Supabase.
 #[derive(Debug, Clone)]
 pub struct SupabaseClient {
-    pub url: String,
-    pub api_key: String,
+    url: String,
+    api_key: String,
+    client: reqwest::Client,
 }
 
 impl SupabaseClient {
@@ -375,11 +379,18 @@ impl SupabaseClient {
     ///     "your-secret-key".to_string(),
     /// );
     /// ```
-    pub fn new(supabase_url: String, private_key: String) -> Self {
-        Self {
+    pub fn new(supabase_url: String, private_key: String) -> Result<Self> {
+        #[cfg(feature = "rustls")]
+        let client = Client::builder().use_rustls_tls().build()?;
+
+        #[cfg(not(feature = "rustls"))]
+        let client = Client::new();
+
+        Ok(Self {
             url: supabase_url,
             api_key: private_key,
-        }
+            client,
+        })
     }
 }
 

--- a/src/routing/id.rs
+++ b/src/routing/id.rs
@@ -24,7 +24,7 @@ impl SupabaseClient {
     ///     let supabase_client = SupabaseClient::new(
     ///         "your_supabase_url".to_string(),
     ///         "your_supabase_key".to_string()
-    ///     );
+    ///     ).unwrap();
     ///     let email = "example@email.com".to_string();
     ///     let table_name = "users".to_string();
     ///     let column_name = "email".to_string();

--- a/src/select.rs
+++ b/src/select.rs
@@ -131,7 +131,7 @@ use crate::SupabaseClient;
 
 use reqwest::header::HeaderMap;
 use reqwest::header::{HeaderName, HeaderValue};
-use reqwest::{Client, Response};
+use reqwest::Response;
 use serde_json::Value;
 
 impl SupabaseClient {
@@ -174,12 +174,6 @@ impl SupabaseClient {
         #[cfg(feature = "nightly")]
         println!("\x1b[33mEndpoint: {}\x1b[0m", endpoint);
 
-        #[cfg(feature = "rustls")]
-        let client = Client::builder().use_rustls_tls().build().unwrap();
-
-        #[cfg(not(feature = "rustls"))]
-        let client: Client = Client::new();
-
         #[cfg(feature = "nightly")]
         use crate::nightly::print_nightly_warning;
         #[cfg(feature = "nightly")]
@@ -204,7 +198,7 @@ impl SupabaseClient {
         }
 
         // send the request
-        let response: Response = match client.get(&endpoint).headers(header_map).send().await {
+        let response: Response = match self.client.get(&endpoint).headers(header_map).send().await {
             Ok(response) => response,
             Err(error) => return Err(error.to_string()),
         };

--- a/src/tests/methods/init.rs
+++ b/src/tests/methods/init.rs
@@ -1,12 +1,13 @@
+use crate::Result;
 use crate::SupabaseClient;
 use dotenv::dotenv;
 use std::env::var;
 
-pub async fn init() -> Result<SupabaseClient, Box<dyn std::error::Error>> {
+pub async fn init() -> Result<SupabaseClient> {
     dotenv().ok();
 
     let supabase_url: String = var("SUPABASE_URL")?;
     let supabase_key: String = var("SUPABASE_KEY")?;
 
-    Ok(SupabaseClient::new(supabase_url, supabase_key))
+    SupabaseClient::new(supabase_url, supabase_key)
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,12 +19,13 @@ pub mod methods {
     pub mod upsert_numeric;
     pub mod upsert_string;
 }
+
 #[cfg(test)]
-pub fn create_test_supabase_client() -> Result<crate::SupabaseClient, Box<dyn std::error::Error>> {
+pub fn create_test_supabase_client() -> crate::Result<crate::SupabaseClient> {
     dotenv::dotenv().ok();
 
     let supabase_url = std::env::var("SUPABASE_URL")?;
     let supabase_key = std::env::var("SUPABASE_KEY")?;
 
-    Ok(crate::SupabaseClient::new(supabase_url, supabase_key))
+    crate::SupabaseClient::new(supabase_url, supabase_key)
 }


### PR DESCRIPTION
By saving the reqwest Client inside `SupabaseClient` we can reuse it, as is recommended by [reqwest's documentation](https://docs.rs/reqwest/latest/reqwest/):

> NOTE: If you plan to perform multiple requests, it is best to create a [Client](https://docs.rs/reqwest/latest/reqwest/struct.Client.html) and reuse it, taking advantage of keep-alive connection pooling.

As I needed some error handling in the new "constructor" I also reduced some boiler plate by using the `thiserror` crate.