### PR TITLE
Extract the crate name and version with env("CARGO_PKG_***")

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ SUPABASE_RS_NO_NIGHTLY_MSG=true
 #### Cargo.toml
 ```toml
 [dependencies]
-supabase-rs = "0.3.7"
+supabase-rs = "..."
 
 // With the [storage] feature
-supabase-rs = { version = "0.3.7", features = ["storage"] }
+supabase-rs = { version = "...", features = ["storage"] }
 ```
 
 #### Usage

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -6,6 +6,7 @@
 //! ## Usage
 //!     
 
+use crate::request::headers::HeadersTypes;
 use crate::SupabaseClient;
 use reqwest::Response;
 use serde_json::json;
@@ -61,9 +62,13 @@ impl SupabaseClient {
         let response: Response = match self
             .client
             .delete(&endpoint)
-            .header("apikey", &self.api_key)
-            .header("Authorization", &format!("Bearer {}", &self.api_key))
-            .header("Content-Type", "application/json")
+            .header(HeadersTypes::ApiKey, &self.api_key)
+            .header(
+                HeadersTypes::Authorization,
+                format!("Bearer {}", &self.api_key),
+            )
+            .header(HeadersTypes::ContentType, "application/json")
+            .header(HeadersTypes::ClientInfo, &crate::client_info())
             .body(body.to_string())
             .send()
             .await

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -50,6 +50,7 @@
 //! Both `insert` and `insert_if_unique` methods return a `Result<String, String>`, where `Ok(String)` contains the ID of the inserted row,
 //! and `Err(String)` contains an error message in case of failure.
 
+use crate::request::headers::HeadersTypes;
 use crate::{generate_random_id, SupabaseClient};
 use reqwest::Response;
 use serde_json::{json, Value};
@@ -94,10 +95,13 @@ impl SupabaseClient {
         let response: Response = match self
             .client
             .post(&endpoint)
-            .header("apikey", &self.api_key)
-            .header("Authorization", format!("Bearer {}", &self.api_key))
-            .header("Content-Type", "application/json")
-            .header("x_client_info", "supabase-rs/0.3.7")
+            .header(HeadersTypes::ApiKey, &self.api_key)
+            .header(
+                HeadersTypes::Authorization,
+                format!("Bearer {}", &self.api_key),
+            )
+            .header(HeadersTypes::ContentType, "application/json")
+            .header(HeadersTypes::ClientInfo, &crate::client_info())
             .body(body.to_string())
             .send()
             .await
@@ -159,10 +163,13 @@ impl SupabaseClient {
         let response: Response = match self
             .client
             .post(&endpoint)
-            .header("apikey", &self.api_key)
-            .header("Authorization", format!("Bearer {}", &self.api_key))
-            .header("Content-Type", "application/json")
-            .header("x_client_info", "supabase-rs/0.3.7")
+            .header(HeadersTypes::ApiKey, &self.api_key)
+            .header(
+                HeadersTypes::Authorization,
+                format!("Bearer {}", &self.api_key),
+            )
+            .header(HeadersTypes::ContentType, "application/json")
+            .header(HeadersTypes::ClientInfo, &crate::client_info())
             .body(body.to_string())
             .send()
             .await
@@ -298,10 +305,13 @@ impl SupabaseClient {
         let response: Response = match self
             .client
             .post(&endpoint)
-            .header("apikey", &self.api_key)
-            .header("Authorization", format!("Bearer {}", &self.api_key))
-            .header("Content-Type", "application/json")
-            .header("x_client_info", "supabase-rs/0.3.7")
+            .header(HeadersTypes::ApiKey, &self.api_key)
+            .header(
+                HeadersTypes::Authorization,
+                format!("Bearer {}", &self.api_key),
+            )
+            .header(HeadersTypes::ContentType, "application/json")
+            .header(HeadersTypes::ClientInfo, &crate::client_info())
             .body(body.to_string())
             .send()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@
 //! ## Cargo.toml
 //! ```toml
 //! [dependencies]
-//! supabase-rs = "0.3.7"
+//! supabase-rs = "..."
 //!
 //! // With the [storage] feature
-//! supabase-rs = { version = "0.3.7", features = ["storage"] }
+//! supabase-rs = { version = "...", features = ["storage"] }
 //! ```
 //!
 //! ## Usage
@@ -324,6 +324,9 @@
 //! ## Contributers
 //!
 
+const PKG_NAME: &'static str = env!("CARGO_PKG_NAME");
+const PKG_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 use rand::prelude::ThreadRng;
 use rand::Rng;
 use reqwest::Client;
@@ -410,4 +413,8 @@ impl SupabaseClient {
 pub fn generate_random_id() -> i64 {
     let mut rng: ThreadRng = rand::thread_rng();
     rng.gen_range(0..i64::MAX)
+}
+
+pub(crate) fn client_info() -> String {
+    format!("{}/{PKG_VERSION}", PKG_NAME.replace("_", "-"))
 }

--- a/src/request/headers.rs
+++ b/src/request/headers.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-
 use crate::request::Headers;
+use reqwest::header::HeaderName;
+use std::collections::HashMap;
 
 impl Default for Headers {
     fn default() -> Self {
@@ -25,7 +25,7 @@ impl Headers {
 
     pub fn with_defaults(api_key: &str, auth_token: &str) -> Self {
         let mut headers = Headers::new();
-        headers.insert(HeadersTypes::ClientInfo.as_str(), "supabase-rs/0.3.7");
+        headers.insert(HeadersTypes::ClientInfo.as_str(), &crate::client_info());
         headers.insert(HeadersTypes::ContentType.as_str(), "application/json");
         headers.insert(HeadersTypes::ApiKey.as_str(), api_key);
         headers.insert(
@@ -53,5 +53,11 @@ impl HeadersTypes {
             HeadersTypes::Prefer => "prefer",
             HeadersTypes::ClientInfo => "x_client_info",
         }
+    }
+}
+
+impl From<HeadersTypes> for HeaderName {
+    fn from(value: HeadersTypes) -> Self {
+        HeaderName::from_bytes(value.as_str().as_bytes()).unwrap()
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -47,6 +47,7 @@
 //!
 //! Both `update` and `upsert` methods return a `Result<(), String>`, where `Ok(())` indicates a successful operation,
 //! and `Err(String)` contains an error message in case of failure.
+use crate::request::headers::HeadersTypes;
 use crate::SupabaseClient;
 use reqwest::Response;
 use serde_json::{json, Value};
@@ -72,9 +73,13 @@ impl SupabaseClient {
         let response: Response = match self
             .client
             .patch(&endpoint)
-            .header("apikey", &self.api_key)
-            .header("Authorization", &format!("Bearer {}", &self.api_key))
-            .header("Content-Type", "application/json")
+            .header(HeadersTypes::ApiKey, &self.api_key)
+            .header(
+                HeadersTypes::Authorization,
+                format!("Bearer {}", &self.api_key),
+            )
+            .header(HeadersTypes::ContentType, "application/json")
+            .header(HeadersTypes::ClientInfo, &crate::client_info())
             .body(body.to_string())
             .send()
             .await
@@ -122,10 +127,13 @@ impl SupabaseClient {
         let response: Response = match self
             .client
             .post(&endpoint)
-            .header("apikey", &self.api_key)
-            .header("Authorization", format!("Bearer {}", &self.api_key))
-            .header("Content-Type", "application/json")
-            .header("x_client_info", "supabase-rs/0.3.1")
+            .header(HeadersTypes::ApiKey, &self.api_key)
+            .header(
+                HeadersTypes::Authorization,
+                format!("Bearer {}", &self.api_key),
+            )
+            .header(HeadersTypes::ContentType, "application/json")
+            .header(HeadersTypes::ClientInfo, &crate::client_info())
             .header("Prefer", "resolution=merge-duplicates")
             .header("Prefer", "return=representation")
             .body(body.to_string())


### PR DESCRIPTION
This way the client info is always up-to-date.

There is no way to read this info for the lib.rs' Rustdoc, so I just replaced the hardcoded `0.3.7` with `...`