### PR TITLE
update fn generate_supabase_types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,9 +397,6 @@ impl SupabaseClient {
         })
     }
 
-
-
-
     /// Returns the base URL of the Supabase project and table.
     ///
     /// # Arguments

--- a/src/type_gen.rs
+++ b/src/type_gen.rs
@@ -57,7 +57,8 @@ pub async fn generate_supabase_types(user: &str, password: &str) {
             "boolean" => "bool",
             "real" | "double precision" => "f64",
             "numeric" | "decimal" => "Decimal",
-            "timestamp without time zone" | "timestamp with time zone" => "NaiveDateTime",
+            "timestamp without time zone" => "NaiveDateTime",
+            "timestamp with time zone" => "DateTime<Utc>",
             "date" => "NaiveDate",
             "uuid" => "Uuid",
             "json" | "jsonb" => "Value",
@@ -86,7 +87,7 @@ pub async fn generate_supabase_types(user: &str, password: &str) {
     output.push_str("#![allow(dead_code)]\n\n");
     output.push_str("use serde::{Serialize, Deserialize};\n\n");
     output.push_str("use serde_json::Value;\n\n");
-    output.push_str("use chrono::{NaiveDate, NaiveDateTime};\n");
+    output.push_str("use chrono::{DateTime, Utc, NaiveDate, NaiveDateTime};\n");
     output.push_str("use uuid::Uuid;\n");
     output.push_str("use rust_decimal::Decimal;\n\n");
     output.push_str("use supabase_rs::SupabaseClient;\n");

--- a/src/type_gen.rs
+++ b/src/type_gen.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
-use std::fs::File;
-use std::fs::OpenOptions;
-use std::io::Read;
-use std::io::Write;
+use std::fs;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
 use std::str::Chars;
 use tokio;
 use tokio_postgres::{Config, NoTls};
 
 pub async fn generate_supabase_types(user: &str, password: &str) {
+    // connect to your supabase Postgres pooler
     let mut config: Config = Config::new();
     config
         .host("aws-0-eu-central-1.pooler.supabase.com")
@@ -21,13 +21,15 @@ pub async fn generate_supabase_types(user: &str, password: &str) {
         .await
         .expect("Failed to connect to database");
 
+    // spawn the connection driver
     tokio::spawn(async move {
         if let Err(e) = connection.await {
             eprintln!("connection error: {e}");
         }
     });
 
-    let query: &str = "
+    // fetch schema info
+    let query: &'static str = "
         SELECT table_name, column_name, data_type, is_nullable
         FROM information_schema.columns
         WHERE table_schema = 'public'
@@ -47,7 +49,7 @@ pub async fn generate_supabase_types(user: &str, password: &str) {
         let data_type: String = row.get("data_type");
         let is_nullable: String = row.get("is_nullable");
 
-        let base_rust_type: &str = match data_type.as_str() {
+        let base_rust_type: &'static str = match data_type.as_str() {
             "integer" => "i32",
             "bigint" => "i64",
             "smallint" => "i16",
@@ -58,10 +60,11 @@ pub async fn generate_supabase_types(user: &str, password: &str) {
             "timestamp without time zone" | "timestamp with time zone" => "NaiveDateTime",
             "date" => "NaiveDate",
             "uuid" => "Uuid",
+            "json" | "jsonb" => "Value",
             _ => "String",
         };
 
-        let rust_type = if is_nullable == "YES" {
+        let rust_type: String = if is_nullable == "YES" {
             format!("Option<{base_rust_type}>")
         } else {
             base_rust_type.to_string()
@@ -70,17 +73,19 @@ pub async fn generate_supabase_types(user: &str, password: &str) {
         table_definitions
             .entry(table_name.clone())
             .or_insert_with(Vec::new)
-            .push((column_name.clone(), rust_type));
+            .push((column_name.clone(), rust_type.clone()));
 
-        // Track column names for the columns method
         all_columns
             .entry(table_name)
             .or_insert_with(Vec::new)
             .push(column_name);
     }
 
+    // start building the file
     let mut output: String = String::new();
+    output.push_str("#![allow(dead_code)]\n\n");
     output.push_str("use serde::{Serialize, Deserialize};\n\n");
+    output.push_str("use serde_json::Value;\n\n");
     output.push_str("use chrono::{NaiveDate, NaiveDateTime};\n");
     output.push_str("use uuid::Uuid;\n");
     output.push_str("use rust_decimal::Decimal;\n\n");
@@ -88,122 +93,96 @@ pub async fn generate_supabase_types(user: &str, password: &str) {
     output.push_str("use supabase_rs::query::QueryBuilder;\n\n");
 
     let mut all_tables: Vec<String> = Vec::new();
+    let mut trait_methods: String = String::new();
+    let mut impl_methods: String = String::new();
 
-    // Add structs for each table and the select method
     for (table, columns) in &table_definitions {
+        let struct_name: String = pascal_case(table);
         all_tables.push(table.clone());
-        let struct_name = pascal_case(table);
 
-        // Generate the struct for the table
+        // struct
         output.push_str(&format!(
             "#[derive(Debug, Serialize, Deserialize)]\npub struct {} {{\n",
             struct_name
         ));
-
         for (col, rust_type) in columns {
-            let field_name = if col == "type" {
+            let field_name: String = if col == "type" {
                 "type_".to_string()
             } else {
                 col.clone()
             };
-            let rename_attr: String = if col == "type" {
+            let rename: String = if col == "type" {
                 format!("    #[serde(rename = \"{col}\")]\n")
             } else {
                 String::new()
             };
-            output.push_str(&rename_attr);
-            output.push_str(&format!("    pub {field_name}: {rust_type},\n"));
+            output.push_str(&rename);
+            output.push_str(&format!("    pub {}: {},\n", field_name, rust_type));
         }
         output.push_str("}\n\n");
 
-        // Generate the columns method for this table
+        // columns fn
         output.push_str(&format!(
-            "impl {struct_name} {{\n    pub fn columns() -> &'static [&'static str] {{\n"
+            "impl {} {{\n    pub fn columns() -> &'static [&'static str] {{\n",
+            struct_name
         ));
-        // Add column names dynamically
-        let column_names = all_columns.get(table).unwrap();
         output.push_str("        &[\n");
-        for col in column_names {
-            output.push_str(&format!("            \"{col}\",\n"));
+        for col in &all_columns[table] {
+            output.push_str(&format!("            \"{}\",\n", col));
         }
-        output.push_str("        ]\n");
-        output.push_str("    }\n}\n\n");
+        output.push_str("        ]\n    }\n}\n\n");
 
-        // Generate the select method for this table
-        output.push_str(&format!(
-            "impl SupabaseClient {{\n    /// ### Columns\n    /// | Column Name | Type | Optional |\n    /// |-------------|------|----------|\n"
+        // extension trait entries
+        let snake: String = snake_case(&struct_name);
+        trait_methods.push_str(&format!(
+            "    fn select_{}(&self) -> QueryBuilder;\n",
+            snake
         ));
-
-        for (col, rust_type) in columns {
-            let optional = if rust_type.contains("Option<") {
-                "Yes"
-            } else {
-                "Required"
-            };
-            output.push_str(&format!(
-                "    /// | {col} | {} | {optional} |\n",
-                rust_type.replace("Option<", "").replace(">", "")
-            ));
-        }
-
-        output.push_str(&format!(
-            "    #[cfg(feature = \"nightly\")]\n    pub fn select_{}(&self) -> QueryBuilder {{\n",
-            snake_case(&struct_name)
-        ));
-
-        output.push_str(&format!(
-            "        QueryBuilder::new(self.clone(), \"{table}\")\n    }}\n}}\n\n"
+        impl_methods.push_str(&format!(
+            "    fn select_{}(&self) -> QueryBuilder {{\n        QueryBuilder::new(self.clone(), \"{}\")\n    }}\n",
+            snake, table
         ));
     }
 
-    // Add a part that contains all tables
+    // ALL_TABLES constant
     output.push_str("pub const ALL_TABLES: &[&str] = &[\n");
-    for table in all_tables {
-        output.push_str(&format!("    \"{table}\",\n"));
+    for table in &all_tables {
+        output.push_str(&format!("    \"{}\",\n", table));
     }
     output.push_str("];\n\n");
 
-    // Write to file
-    use std::fs;
-    if fs::metadata("src/lib.rs").is_ok() {
-        let mut lib_rs: File = OpenOptions::new()
-            .read(true)
-            .open("src/lib.rs")
-            .expect("Failed to open lib.rs");
-        let mut contents = String::new();
-        lib_rs
-            .read_to_string(&mut contents)
-            .expect("Failed to read lib.rs");
+    // emit extension trait + impl
+    output.push_str("pub trait SupabaseClientExt {\n");
+    output.push_str(&trait_methods);
+    output.push_str("}\n\n");
+    output.push_str("impl SupabaseClientExt for SupabaseClient {\n");
+    output.push_str(&impl_methods);
+    output.push_str("}\n\n");
 
+    // write to file & update mod declaration
+    if fs::metadata("src/lib.rs").is_ok() {
+        let mut lib_rs: File = OpenOptions::new().read(true).open("src/lib.rs").unwrap();
+        let mut contents: String = String::new();
+        lib_rs.read_to_string(&mut contents).unwrap();
         if !contents.contains("pub mod supabase_types;") {
-            let mut lib_rs: File = OpenOptions::new()
+            let mut lib_rs = OpenOptions::new()
                 .write(true)
                 .append(true)
                 .open("src/lib.rs")
-                .expect("Failed to open lib.rs");
-            lib_rs
-                .write_all(b"pub mod supabase_types;\n")
-                .expect("Failed to write to lib.rs");
+                .unwrap();
+            lib_rs.write_all(b"pub mod supabase_types;\n").unwrap();
         }
     } else if fs::metadata("src/mod.rs").is_ok() {
-        let mut mod_rs: File = OpenOptions::new()
-            .read(true)
-            .open("src/mod.rs")
-            .expect("Failed to open mod.rs");
-        let mut contents = String::new();
-        mod_rs
-            .read_to_string(&mut contents)
-            .expect("Failed to read mod.rs");
-
+        let mut mod_rs: File = OpenOptions::new().read(true).open("src/mod.rs").unwrap();
+        let mut contents: String = String::new();
+        mod_rs.read_to_string(&mut contents).unwrap();
         if !contents.contains("pub mod supabase_types;") {
             let mut mod_rs: File = OpenOptions::new()
                 .write(true)
                 .append(true)
                 .open("src/mod.rs")
-                .expect("Failed to open mod.rs");
-            mod_rs
-                .write_all(b"pub mod supabase_types;\n")
-                .expect("Failed to write to mod.rs");
+                .unwrap();
+            mod_rs.write_all(b"pub mod supabase_types;\n").unwrap();
         }
     }
 
@@ -212,14 +191,13 @@ pub async fn generate_supabase_types(user: &str, password: &str) {
             .expect("Failed to remove existing supabase_types.rs");
     }
 
-    let mut file = OpenOptions::new()
+    let mut file: File = OpenOptions::new()
+        .create(true)
         .write(true)
         .append(true)
-        .create(true)
         .open("src/supabase_types.rs")
-        .expect("Failed to open or create file");
-    file.write_all(output.as_bytes())
-        .expect("Failed to write file");
+        .unwrap();
+    file.write_all(output.as_bytes()).unwrap();
 }
 
 fn pascal_case(s: &str) -> String {
@@ -231,7 +209,7 @@ fn pascal_case(s: &str) -> String {
                 None => String::new(),
             }
         })
-        .collect::<String>()
+        .collect()
 }
 
 fn snake_case(s: &str) -> String {

--- a/src/type_gen.rs
+++ b/src/type_gen.rs
@@ -103,7 +103,7 @@ pub async fn generate_supabase_types(user: &str, password: &str) {
 
         // struct
         output.push_str(&format!(
-            "#[derive(Debug, Serialize, Deserialize)]\npub struct {} {{\n",
+            "#[derive(Debug, Serialize, Deserialize, Clone)]\npub struct {} {{\n",
             struct_name
         ));
         for (col, rust_type) in columns {


### PR DESCRIPTION
Add serde_json::Value mapping for json/jsonb types

Change base_rust_type to &'static str and properly clone nullable types

Build columns() and extension traits dynamically instead of inline literals

Emit SupabaseClientExt trait with select_table methods

Ensure pub mod supabase_types; is appended to lib.rs/mod.rs only once

After you have generated your supabase_types.rs u you can do the following

```
mod supabase_types;                    // 1. declare the generated module
use supabase_types::SupabaseClientExt; // 2. import the trait
use supabase_rs::SupabaseClient;       // 3. import the SupabaseClient 

use serde_json::Value;

#[tokio::main]
async fn main() -> std::io::Result<()> {

    let supabase: SupabaseClient = SupabaseClient::new(
        "URL".to_string(),
        "KEY".to_string(),
    ).unwrap();

    let rows: Vec<Value> = supabase
        .select_monitors()    // now available
        .eq("id", "1")
        .columns(vec!["expected_json_body"])
        .limit(10)
        .execute()
        .await
        .unwrap();

    println!("Got {:#?} rows", rows);
    Ok(())
}
```