### PR TITLE
supports operations on non-public schemas

### DIFF
--- a/src/delete.rs
+++ b/src/delete.rs
@@ -222,6 +222,7 @@ impl SupabaseClient {
             )
             .header(HeadersTypes::ContentType, "application/json")
             .header(HeadersTypes::ClientInfo, &crate::client_info())
+            .header(HeadersTypes::AcceptProfile.as_str(), self.schema.as_str())
             .body(body.to_string())
             .send()
             .await
@@ -266,6 +267,7 @@ impl SupabaseClient {
             )
             .header(HeadersTypes::ContentType, "application/json")
             .header(HeadersTypes::ClientInfo, &crate::client_info())
+            .header(HeadersTypes::AcceptProfile.as_str(), self.schema.as_str())
             .body(body.to_string())
             .send()
             .await

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -32,7 +32,7 @@
 //!
 //! ```rust,no_run
 //! use supabase_rs::SupabaseClient;
-//! use supabase_rs::graphql::{Request, RootTypes};
+//! use supabase_rs::graphql::{request::Request, RootTypes};
 //! use serde_json::json;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -75,7 +75,7 @@
 //!
 //! ```rust,no_run
 //! # use supabase_rs::SupabaseClient;
-//! # use supabase_rs::graphql::{Request, RootTypes};
+//! # use supabase_rs::graphql::{request::Request, RootTypes};
 //! # use serde_json::json;
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! # let client = SupabaseClient::new("url".to_string(), "key".to_string())?;
@@ -116,7 +116,7 @@
 //!
 //! ```rust,no_run
 //! # use supabase_rs::SupabaseClient;
-//! # use supabase_rs::graphql::{Request, RootTypes};
+//! # use supabase_rs::graphql::{request::Request, RootTypes};
 //! # use serde_json::json;
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! # let client = SupabaseClient::new("url".to_string(), "key".to_string())?;
@@ -168,7 +168,7 @@
 //!
 //! ```rust,no_run
 //! # use supabase_rs::SupabaseClient;
-//! # use supabase_rs::graphql::{Request, RootTypes};
+//! # use supabase_rs::graphql::{request::Request, RootTypes};
 //! # use serde_json::json;
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! # let client = SupabaseClient::new("url".to_string(), "key".to_string())?;

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -303,8 +303,8 @@ impl SupabaseClient {
                 Ok(text) => text,
                 Err(e) => return Err(format!("Failed to get response text: {}", e)),
             };
-            let id: String = match serde_json::from_str::<Value>(&res_text) {
-                Ok(json) => json["id"].to_string(),
+            let id: String = match serde_json::from_str::<Vec<Value>>(&res_text) {
+                Ok(json) => json[0]["id"].to_string(),
                 Err(e) => return Err(format!("Failed to parse response text: {}", e)),
             };
             Ok(id)

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -148,7 +148,7 @@
 //! # async fn example() -> Result<(), String> {
 //! # let client = SupabaseClient::new("url".to_string(), "key".to_string()).unwrap();
 //! // ✅ Good: Batch multiple inserts
-//! let records = vec![/* ... multiple records ... */];
+//! let records = vec![json!({"name":"tom"})/* ... multiple records ... */];
 //! client.bulk_insert("logs", records).await?;
 //!
 //! // ❌ Avoid: Individual inserts in loops
@@ -215,6 +215,7 @@ impl SupabaseClient {
             )
             .header(HeadersTypes::ContentType, "application/json")
             .header(HeadersTypes::ClientInfo, &crate::client_info())
+            .header(HeadersTypes::AcceptProfile.as_str(), self.schema.as_str())
             .body(body.to_string())
             .send()
             .await
@@ -288,6 +289,7 @@ impl SupabaseClient {
             .header(HeadersTypes::ContentType, "application/json")
             .header(HeadersTypes::ClientInfo, &crate::client_info())
             .header(HeadersTypes::Prefer, "return=representation")
+            .header(HeadersTypes::AcceptProfile.as_str(), self.schema.as_str())
             .body(body.to_string())
             .send()
             .await
@@ -484,6 +486,7 @@ impl SupabaseClient {
             )
             .header(HeadersTypes::ContentType, "application/json")
             .header(HeadersTypes::ClientInfo, &crate::client_info())
+            .header(HeadersTypes::AcceptProfile.as_str(), self.schema.as_str())
             .body(body.to_string())
             .send()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,6 +506,7 @@ use errors::Result;
 pub struct SupabaseClient {
     url: String,
     api_key: String,
+    schema: String,
     client: reqwest::Client,
 }
 
@@ -583,8 +584,14 @@ impl SupabaseClient {
         Ok(Self {
             url: supabase_url,
             api_key: private_key,
+            schema: "public".to_string(), // default schema
             client,
         })
+    }
+
+    pub fn schema(mut self, schema: &str) -> Self {
+        self.schema = schema.to_string();
+        self
     }
 
     /// Returns the base URL of the Supabase project and table.

--- a/src/request/headers.rs
+++ b/src/request/headers.rs
@@ -43,6 +43,7 @@ pub enum HeadersTypes {
     Prefer,
     ClientInfo,
     Range,
+    AcceptProfile,
 }
 
 impl HeadersTypes {
@@ -54,6 +55,7 @@ impl HeadersTypes {
             HeadersTypes::Prefer => "prefer",
             HeadersTypes::ClientInfo => "x_client_info",
             HeadersTypes::Range => "Range",
+            HeadersTypes::AcceptProfile => "Accept-Profile",
         }
     }
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -180,6 +180,7 @@
 //! ```
 
 use crate::query::{Query, QueryBuilder};
+use crate::request::headers::HeadersTypes;
 use crate::request::Headers;
 use crate::success::handle_response;
 use crate::SupabaseClient;
@@ -261,7 +262,9 @@ impl SupabaseClient {
         };
 
         // create headers with default values
-        let headers: Headers = Headers::with_defaults(&self.api_key, &self.api_key);
+        let mut headers: Headers = Headers::with_defaults(&self.api_key, &self.api_key);
+
+        headers.insert(HeadersTypes::AcceptProfile.as_str(), self.schema.as_str());
 
         // convert headers to HeaderMap
         let mut header_map: HeaderMap = HeaderMap::new();
@@ -325,6 +328,8 @@ impl SupabaseClient {
         if let Some((from, to)) = query.get_range() {
             headers.insert("Range", &format!("{}-{}", from, to));
         }
+
+        headers.insert(HeadersTypes::AcceptProfile.as_str(), self.schema.as_str());        
 
         // convert headers to HeaderMap
         let mut header_map: HeaderMap = HeaderMap::new();

--- a/src/update.rs
+++ b/src/update.rs
@@ -186,6 +186,7 @@ impl SupabaseClient {
             )
             .header(HeadersTypes::ContentType, "application/json")
             .header(HeadersTypes::ClientInfo, &crate::client_info())
+            .header(HeadersTypes::AcceptProfile.as_str(), self.schema.as_str())
             .body(body.to_string())
             .send()
             .await
@@ -240,8 +241,9 @@ impl SupabaseClient {
             )
             .header(HeadersTypes::ContentType, "application/json")
             .header(HeadersTypes::ClientInfo, &crate::client_info())
-            .header("Prefer", "resolution=merge-duplicates")
-            .header("Prefer", "return=representation")
+            .header(HeadersTypes::AcceptProfile.as_str(), self.schema.as_str())
+            .header(HeadersTypes::Prefer.as_str(), "resolution=merge-duplicates")
+            .header(HeadersTypes::Prefer.as_str(), "return=representation")
             .body(body.to_string())
             .send()
             .await


### PR DESCRIPTION
- add **schema** in SupabaseClient, lib.rs
- add a new header **Accept-Profile** in every request, request/headers.rs@46/58, delete.rs/insert.rs/select.rs/update.rs
- _use supabase_rs::graphql::{Request, RootTypes}_   to _use supabase_rs::graphql::{request::Request, RootTypes}_ , graphql/mod.rs@35/78/119/171
- _let records = vec![/* ... multiple records ... */]_  to _let records = vec![json!({"name":"tom"})/* ... multiple records ... */]_ , insert.rs@151