### PR TITLE
Bump reqwest version to 0.13.1 and Fix features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/floris-xlx/supabase_rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.12.3", default-features = false, features = ["gzip", "json"] }
+reqwest = { version = "0.13.1", default-features = false, features = ["gzip", "json"] }
 rand = "0.9.0"
 serde_json = "1.0.111"
 dotenv = "0.15.0"
@@ -34,7 +34,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 default = ["native_tls", "nightly"]
 nightly = []
 storage = []
-rustls = ["reqwest/rustls-tls"]
+rustls = ["reqwest/rustls"]
 native_tls = ["reqwest/native-tls"]
 
 # default = ["nightly"]


### PR DESCRIPTION
Accding to [this](https://github.com/seanmonstar/reqwest/releases/tag/v0.13.0), rustls-tls has been renamed to rustls.
