### PR TITLE
Update rand dependency to version 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/floris-xlx/supabase_rs"
 
 [dependencies]
 reqwest = { version = "0.13.1", default-features = false, features = ["gzip", "json"] }
-rand = "0.9.0"
+rand = "0.10.0"
 serde_json = "1.0.111"
 dotenv = "0.15.0"
 anyhow = "1.0.86"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,7 +411,7 @@ const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use rand::prelude::ThreadRng;
-use rand::Rng;
+use rand::RngExt;
 use reqwest::Client;
 
 pub mod delete;


### PR DESCRIPTION
https://github.com/rust-random/rand/blob/master/CHANGELOG.md#0100---2026-02-08
> Rename Rng -> RngExt as upstream rand_core has renamed RngCore -> Rng